### PR TITLE
Fix setup.py to treat `congress` as a package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description = README,
     author = "Chris Amico",
     author_email = "eyeseast@gmail.com",
-    py_modules = ['congress'],
+    packages = ['congress'],
     install_requires = ['httplib2', 'six'],
     platforms= ['any'],
     classifiers = [


### PR DESCRIPTION
Installation fails without this change.

When running `python setup.py install` look for:
```
running build_py
file congress.py (for module congress) not found
file congress.py (for module congress) not found
```